### PR TITLE
allow fixed token supply configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Partner can specify these parameters when they create a configuration on all the
 - `quote_mint`: the quote mint address that virtual pool will support.
 - `locked_vesting`: locked vesting for creator after token is migrated (token will be migrated to [Jup lock](https://lock.jup.ag/))
 - `migration_fee_option`: allow partner to choose a fee option on graduated pool (currently support 0.25% | 0.3% | 1% | 2%)
+- `token_supply`: when the fields are specified, token will have fixed supply in pre and post migration, leftover will be returned to leftover_receiver (configured in config key)
 - `sqrt_start_price`: square root of min price in the bonding curve for the virtual pools.
 - `curve`: an array of square price and liquidity, that defines the liquidity distribution for the virtual pools.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "^2.6.2",
     "ts-mocha": "^10.0.0",
     "typescript": "^4.3.5",
-    "solana-bankrun": "^0.4.0"
+    "solana-bankrun": "^0.4.0",
+    "decimal.js": "^10.4.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       chai:
         specifier: ^4.3.4
         version: 4.5.0
+      decimal.js:
+        specifier: ^10.4.2
+        version: 10.5.0
       mocha:
         specifier: ^9.0.3
         version: 9.2.2
@@ -327,6 +330,9 @@ packages:
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
+
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
@@ -1158,6 +1164,8 @@ snapshots:
       supports-color: 8.1.1
 
   decamelize@4.0.0: {}
+
+  decimal.js@10.5.0: {}
 
   deep-eql@4.1.4:
     dependencies:

--- a/programs/virtual-curve/src/constants.rs
+++ b/programs/virtual-curve/src/constants.rs
@@ -18,8 +18,6 @@ pub const BIN_STEP_BPS_U128_DEFAULT: u128 = 1844674407370955;
 
 pub const MAX_CURVE_POINT: usize = 20;
 
-// pub const MAX_TOKEN_SUPPLY: u64 = 10_000_000_000; // 10 billion
-
 pub const SWAP_BUFFER_PERCENTAGE: u8 = 25; // 25%
 
 pub const PARTNER_SURPLUS_SHARE: u8 = 90; // 90 %

--- a/programs/virtual-curve/src/constants.rs
+++ b/programs/virtual-curve/src/constants.rs
@@ -18,7 +18,9 @@ pub const BIN_STEP_BPS_U128_DEFAULT: u128 = 1844674407370955;
 
 pub const MAX_CURVE_POINT: usize = 20;
 
-pub const MAX_TOKEN_SUPPLY: u64 = 10_000_000_000; // 10 billion
+// pub const MAX_TOKEN_SUPPLY: u64 = 10_000_000_000; // 10 billion
+
+pub const SWAP_BUFFER_PERCENTAGE: u8 = 25; // 25%
 
 pub const PARTNER_SURPLUS_SHARE: u8 = 90; // 90 %
 

--- a/programs/virtual-curve/src/constants.rs
+++ b/programs/virtual-curve/src/constants.rs
@@ -1,3 +1,5 @@
+use static_assertions::const_assert;
+
 /// refer raydium clmm
 pub const MIN_SQRT_PRICE: u128 = 4295048016;
 /// refer raydium clmm
@@ -16,7 +18,9 @@ pub const BIN_STEP_BPS_U128_DEFAULT: u128 = 1844674407370955;
 
 // Number of bits to scale. This will decide the position of the radix point.
 
-pub const MAX_CURVE_POINT: usize = 20;
+pub const MAX_CURVE_POINT: usize = 16;
+pub const MAX_CURVE_POINT_CONFIG: usize = 20;
+const_assert!(MAX_CURVE_POINT <= MAX_CURVE_POINT_CONFIG);
 
 pub const SWAP_BUFFER_PERCENTAGE: u8 = 25; // 25%
 

--- a/programs/virtual-curve/src/error.rs
+++ b/programs/virtual-curve/src/error.rs
@@ -100,4 +100,7 @@ pub enum PoolError {
 
     #[msg("Invalid vesting parameters")]
     InvalidVestingParameters,
+
+    #[msg("Invalid leftover address")]
+    InvalidLeftoverAddress,
 }

--- a/programs/virtual-curve/src/error.rs
+++ b/programs/virtual-curve/src/error.rs
@@ -65,6 +65,9 @@ pub enum PoolError {
     #[msg("Invalid quote threshold")]
     InvalidQuoteThreshold,
 
+    #[msg("Invalid token supply")]
+    InvalidTokenSupply,
+
     #[msg("Invalid curve")]
     InvalidCurve,
 
@@ -79,6 +82,9 @@ pub enum PoolError {
 
     #[msg("Surplus has been withdraw")]
     SurplusHasBeenWithdraw,
+
+    #[msg("Leftover has been withdraw")]
+    LeftoverHasBeenWithdraw,
 
     #[msg("Total base token is exceeded max supply")]
     TotalBaseTokenExceedMaxSupply,

--- a/programs/virtual-curve/src/event.rs
+++ b/programs/virtual-curve/src/event.rs
@@ -45,7 +45,7 @@ pub struct EvtCreateConfig {
     pub sqrt_start_price: u128,
     pub locked_vesting: LockedVestingParams,
     pub migration_fee_option: u8,
-    pub fixed_token_suppply_flag: u8,
+    pub fixed_token_supply_flag: u8,
     pub pre_migration_token_supply: u64,
     pub post_migration_token_supply: u64,
     pub curve: Vec<LiquidityDistributionParameters>,

--- a/programs/virtual-curve/src/event.rs
+++ b/programs/virtual-curve/src/event.rs
@@ -6,7 +6,7 @@ use crate::{
         fee_parameters::PoolFeeParameters, liquidity_distribution::LiquidityDistributionParameters,
     },
     state::SwapResult,
-    SwapParameters,
+    LockedVestingParams, SwapParameters,
 };
 
 /// Create partner metadata
@@ -43,6 +43,11 @@ pub struct EvtCreateConfig {
     pub migration_quote_threshold: u64,
     pub migration_base_amount: u64,
     pub sqrt_start_price: u128,
+    pub locked_vesting: LockedVestingParams,
+    pub migration_fee_option: u8,
+    pub fixed_token_suppply_flag: u8,
+    pub pre_migration_token_supply: u64,
+    pub post_migration_token_supply: u64,
     pub curve: Vec<LiquidityDistributionParameters>,
 }
 
@@ -123,4 +128,11 @@ pub struct EvtProtocolWithdrawSurplus {
 pub struct EvtPartnerWithdrawSurplus {
     pub pool: Pubkey,
     pub surplus_amount: u64,
+}
+
+#[event]
+pub struct EvtWithdrawLeftover {
+    pub pool: Pubkey,
+    pub leftover_receiver: Pubkey,
+    pub leftover_amount: u64,
 }

--- a/programs/virtual-curve/src/instructions/migration/meteora_damm/migrate_meteora_damm_initialize_pool.rs
+++ b/programs/virtual-curve/src/instructions/migration/meteora_damm/migrate_meteora_damm_initialize_pool.rs
@@ -250,7 +250,8 @@ pub fn handle_migrate_meteora_damm<'info>(
         .amount
         .safe_sub(virtual_pool.get_protocol_and_partner_base_fee()?)?;
 
-    if left_base_token > 0 {
+    let burnable_amount = config.get_burnable_amount_post_migration(left_base_token)?;
+    if burnable_amount > 0 {
         let seeds = pool_authority_seeds!(const_pda::pool_authority::BUMP);
         anchor_spl::token::burn(
             CpiContext::new_with_signer(
@@ -262,7 +263,7 @@ pub fn handle_migrate_meteora_damm<'info>(
                 },
                 &[&seeds[..]],
             ),
-            left_base_token,
+            burnable_amount,
         )?;
     }
 

--- a/programs/virtual-curve/src/instructions/migration/mod.rs
+++ b/programs/virtual-curve/src/instructions/migration/mod.rs
@@ -4,3 +4,5 @@ pub mod dynamic_amm_v2;
 pub use dynamic_amm_v2::*;
 pub mod create_locker;
 pub use create_locker::*;
+pub mod withdraw_leftover;
+pub use withdraw_leftover::*;

--- a/programs/virtual-curve/src/instructions/migration/withdraw_leftover.rs
+++ b/programs/virtual-curve/src/instructions/migration/withdraw_leftover.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::{
-    constants::seeds::POOL_AUTHORITY_PREFIX,
+    const_pda,
     safe_math::SafeMath,
     state::{MigrationProgress, PoolConfig, VirtualPool},
     token::transfer_from_pool,
@@ -14,7 +14,9 @@ use crate::{
 #[derive(Accounts)]
 pub struct WithdrawLeftoverCtx<'info> {
     /// CHECK: pool authority
-    #[account(seeds = [POOL_AUTHORITY_PREFIX.as_ref()], bump)]
+    #[account(
+        address = const_pda::pool_authority::ID
+    )]
     pub pool_authority: UncheckedAccount<'info>,
 
     #[account(has_one=leftover_receiver)]
@@ -83,7 +85,7 @@ pub fn handle_withdraw_leftover(ctx: Context<WithdrawLeftoverCtx>) -> Result<()>
         &ctx.accounts.token_base_account,
         &ctx.accounts.token_base_program,
         leftover_amount,
-        ctx.bumps.pool_authority,
+        const_pda::pool_authority::BUMP,
     )?;
 
     // update partner withdraw leftover

--- a/programs/virtual-curve/src/instructions/migration/withdraw_leftover.rs
+++ b/programs/virtual-curve/src/instructions/migration/withdraw_leftover.rs
@@ -1,0 +1,98 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
+
+use crate::{
+    constants::seeds::POOL_AUTHORITY_PREFIX,
+    safe_math::SafeMath,
+    state::{MigrationProgress, PoolConfig, VirtualPool},
+    token::transfer_from_pool,
+    EvtWithdrawLeftover, PoolError,
+};
+
+/// Accounts for withdraw leftover
+#[event_cpi]
+#[derive(Accounts)]
+pub struct WithdrawLeftoverCtx<'info> {
+    /// CHECK: pool authority
+    #[account(seeds = [POOL_AUTHORITY_PREFIX.as_ref()], bump)]
+    pub pool_authority: UncheckedAccount<'info>,
+
+    #[account(has_one=leftover_receiver)]
+    pub config: AccountLoader<'info, PoolConfig>,
+
+    #[account(
+        mut,
+        has_one = base_mint,
+        has_one = base_vault,
+        has_one = config,
+    )]
+    pub virtual_pool: AccountLoader<'info, VirtualPool>,
+
+    /// The receiver token account, withdraw to ATA
+    #[account(mut,
+        associated_token::authority = leftover_receiver,
+        associated_token::mint = base_mint,
+        associated_token::token_program = token_base_program
+    )]
+    pub token_base_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The vault token account for output token
+    #[account(mut, token::token_program = token_base_program, token::mint = base_mint)]
+    pub base_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The mint of quote token
+    pub base_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    /// CHECK: leftover receiver
+    pub leftover_receiver: UncheckedAccount<'info>,
+
+    /// Token base program
+    pub token_base_program: Interface<'info, TokenInterface>,
+}
+
+pub fn handle_withdraw_leftover(ctx: Context<WithdrawLeftoverCtx>) -> Result<()> {
+    let config = ctx.accounts.config.load()?;
+
+    let mut virtual_pool = ctx.accounts.virtual_pool.load_mut()?;
+    require!(
+        virtual_pool.get_migration_progress()? == MigrationProgress::CreatedPool,
+        PoolError::NotPermitToDoThisAction
+    );
+
+    require!(
+        config.is_fixed_token_supply(),
+        PoolError::NotPermitToDoThisAction
+    );
+
+    // Ensure the leftover has never been withdrawn
+    require!(
+        virtual_pool.is_withdraw_leftover == 0,
+        PoolError::LeftoverHasBeenWithdraw
+    );
+
+    let leftover_amount = ctx
+        .accounts
+        .base_vault
+        .amount
+        .safe_sub(virtual_pool.get_protocol_and_partner_base_fee()?)?;
+
+    transfer_from_pool(
+        ctx.accounts.pool_authority.to_account_info(),
+        &ctx.accounts.base_mint,
+        &ctx.accounts.base_vault,
+        &ctx.accounts.token_base_account,
+        &ctx.accounts.token_base_program,
+        leftover_amount,
+        ctx.bumps.pool_authority,
+    )?;
+
+    // update partner withdraw leftover
+    virtual_pool.update_withdraw_leftover();
+
+    emit_cpi!(EvtWithdrawLeftover {
+        pool: ctx.accounts.virtual_pool.key(),
+        leftover_receiver: ctx.accounts.leftover_receiver.key(),
+        leftover_amount,
+    });
+    Ok(())
+}

--- a/programs/virtual-curve/src/instructions/partner/ix_create_config.rs
+++ b/programs/virtual-curve/src/instructions/partner/ix_create_config.rs
@@ -4,7 +4,7 @@ use locker::types::CreateVestingEscrowParameters;
 
 use crate::{
     activation_handler::ActivationType,
-    constants::{MAX_CURVE_POINT, MAX_SQRT_PRICE, MIN_SQRT_PRICE},
+    constants::{MAX_CURVE_POINT, MAX_SQRT_PRICE, MIN_SQRT_PRICE, SWAP_BUFFER_PERCENTAGE},
     params::{
         fee_parameters::PoolFeeParameters,
         liquidity_distribution::{
@@ -37,11 +37,19 @@ pub struct ConfigParameters {
     pub sqrt_start_price: u128,
     pub locked_vesting: LockedVestingParams,
     pub migration_fee_option: u8,
+    pub token_supply: Option<TokenSupplyParams>,
     /// padding for future use
-    pub padding: [u8; 7],
+    pub padding: [u64; 8],
     pub curve: Vec<LiquidityDistributionParameters>,
 }
 
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, Default, PartialEq)]
+pub struct TokenSupplyParams {
+    /// pre migration token supply
+    pub pre_migration_token_supply: u64,
+    /// post migration token supply
+    pub post_migration_token_supply: u64,
+}
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, Default, PartialEq)]
 pub struct LockedVestingParams {
     pub amount_per_period: u64,
@@ -137,9 +145,7 @@ impl ConfigParameters {
                 );
             }
             MigrationOption::DammV2 => {
-                // skip that check, we will deploy damm v2 soon
-                // #[cfg(not(feature = "local"))]
-                // return Err(PoolError::InvalidMigrationOption.into());
+                // nothing to check
             }
         }
 
@@ -212,7 +218,6 @@ impl ConfigParameters {
 
 #[event_cpi]
 #[derive(Accounts)]
-#[instruction(config_parameters: ConfigParameters)]
 pub struct CreateConfigCtx<'info> {
     #[account(
         init,
@@ -224,8 +229,8 @@ pub struct CreateConfigCtx<'info> {
 
     /// CHECK: fee_claimer
     pub fee_claimer: UncheckedAccount<'info>,
-    /// CHECK: owner of the config
-    pub owner: UncheckedAccount<'info>,
+    /// CHECK: owner extra base token in case token is fixed supply
+    pub leftover_receiver: UncheckedAccount<'info>,
     /// quote mint
     pub quote_mint: Box<InterfaceAccount<'info, Mint>>,
 
@@ -256,6 +261,7 @@ pub fn handle_create_config(
         sqrt_start_price,
         locked_vesting,
         migration_fee_option,
+        token_supply,
         curve,
         ..
     } = config_parameters;
@@ -272,26 +278,42 @@ pub fn handle_create_config(
             .map_err(|_| PoolError::InvalidMigrationOption)?,
     )?;
 
-    let total_base_with_buffer =
-        PoolConfig::total_amount_with_buffer(swap_base_amount, migration_base_amount)?;
-    let max_supply = PoolConfig::get_max_supply(token_decimal)?;
-    require!(
-        total_base_with_buffer <= max_supply,
-        PoolError::TotalBaseTokenExceedMaxSupply
-    );
+    let minimum_base_supply_with_buffer = PoolConfig::total_amount_with_buffer(
+        swap_base_amount,
+        migration_base_amount,
+        &locked_vesting,
+        SWAP_BUFFER_PERCENTAGE,
+    )?;
 
-    // validate total token is smaller than u64::MAX
-    require!(
-        total_base_with_buffer.safe_add(locked_vesting.get_total_amount()?.into())?
-            <= u64::MAX.into(),
-        PoolError::InvalidVestingParameters
-    );
+    let minimum_base_supply_without_buffer = PoolConfig::total_amount_with_buffer(
+        swap_base_amount,
+        migration_base_amount,
+        &locked_vesting,
+        0,
+    )?;
+
+    let (fixed_token_suppply_flag, pre_migration_token_supply, post_migration_token_supply) =
+        if let Some(TokenSupplyParams {
+            pre_migration_token_supply,
+            post_migration_token_supply,
+        }) = token_supply
+        {
+            require!(
+                minimum_base_supply_without_buffer <= post_migration_token_supply
+                    && post_migration_token_supply <= pre_migration_token_supply
+                    && minimum_base_supply_with_buffer <= pre_migration_token_supply,
+                PoolError::InvalidTokenSupply
+            );
+            (1, pre_migration_token_supply, post_migration_token_supply)
+        } else {
+            (0, 0, 0)
+        };
 
     let mut config = ctx.accounts.config.load_init()?;
     config.init(
         &ctx.accounts.quote_mint.key(),
         ctx.accounts.fee_claimer.key,
-        ctx.accounts.owner.key,
+        ctx.accounts.leftover_receiver.key,
         &pool_fees,
         collect_fee_mode,
         migration_option,
@@ -310,6 +332,9 @@ pub fn handle_create_config(
         migration_base_amount,
         sqrt_migration_price,
         sqrt_start_price,
+        fixed_token_suppply_flag,
+        pre_migration_token_supply,
+        post_migration_token_supply,
         &curve,
     );
 
@@ -317,7 +342,7 @@ pub fn handle_create_config(
         config: ctx.accounts.config.key(),
         fee_claimer: ctx.accounts.fee_claimer.key(),
         quote_mint: ctx.accounts.quote_mint.key(),
-        owner: ctx.accounts.owner.key(),
+        owner: ctx.accounts.leftover_receiver.key(),
         pool_fees,
         collect_fee_mode,
         migration_option,
@@ -332,6 +357,11 @@ pub fn handle_create_config(
         migration_quote_threshold,
         migration_base_amount,
         sqrt_start_price,
+        fixed_token_suppply_flag,
+        pre_migration_token_supply,
+        post_migration_token_supply,
+        locked_vesting,
+        migration_fee_option,
         curve
     });
 

--- a/programs/virtual-curve/src/instructions/partner/ix_create_config.rs
+++ b/programs/virtual-curve/src/instructions/partner/ix_create_config.rs
@@ -296,12 +296,16 @@ pub fn handle_create_config(
         &locked_vesting,
     )?;
 
-    let (fixed_token_suppply_flag, pre_migration_token_supply, post_migration_token_supply) =
+    let (fixed_token_supply_flag, pre_migration_token_supply, post_migration_token_supply) =
         if let Some(TokenSupplyParams {
             pre_migration_token_supply,
             post_migration_token_supply,
         }) = token_supply
         {
+            require!(
+                ctx.accounts.leftover_receiver.key() != Pubkey::default(),
+                PoolError::InvalidLeftoverAddress
+            );
             require!(
                 minimum_base_supply_without_buffer <= post_migration_token_supply
                     && post_migration_token_supply <= pre_migration_token_supply
@@ -336,7 +340,7 @@ pub fn handle_create_config(
         migration_base_amount,
         sqrt_migration_price,
         sqrt_start_price,
-        fixed_token_suppply_flag,
+        fixed_token_supply_flag,
         pre_migration_token_supply,
         post_migration_token_supply,
         &curve,
@@ -361,7 +365,7 @@ pub fn handle_create_config(
         migration_quote_threshold,
         migration_base_amount,
         sqrt_start_price,
-        fixed_token_suppply_flag,
+        fixed_token_supply_flag,
         pre_migration_token_supply,
         post_migration_token_supply,
         locked_vesting,

--- a/programs/virtual-curve/src/lib.rs
+++ b/programs/virtual-curve/src/lib.rs
@@ -69,6 +69,7 @@ pub mod virtual_curve {
         instructions::handle_claim_trading_fee(ctx, max_amount_a, max_amount_b)
     }
 
+    // withdraw surplus on quote token
     pub fn partner_withdraw_surplus(ctx: Context<PartnerWithdrawSurplusCtx>) -> Result<()> {
         instructions::handle_partner_withdraw_surplus(ctx)
     }
@@ -105,6 +106,12 @@ pub mod virtual_curve {
     pub fn create_locker(ctx: Context<CreateLockerCtx>) -> Result<()> {
         instructions::handle_create_locker(ctx)
     }
+
+    // withdraw leftover on base token, can only call after pool is initialized
+    pub fn withdraw_leftover(ctx: Context<WithdrawLeftoverCtx>) -> Result<()> {
+        instructions::handle_withdraw_leftover(ctx)
+    }
+
     /// migrate damm v1
     pub fn migration_meteora_damm_create_metadata<'c: 'info, 'info>(
         ctx: Context<'_, '_, 'c, 'info, MigrationMeteoraDammCreateMetadataCtx<'info>>,

--- a/programs/virtual-curve/src/params/liquidity_distribution.rs
+++ b/programs/virtual-curve/src/params/liquidity_distribution.rs
@@ -6,9 +6,8 @@ use ruint::aliases::U256;
 use crate::{
     constants::{MAX_SQRT_PRICE, MIN_SQRT_PRICE},
     curve::{
-        get_delta_amount_base_unsigned, get_delta_amount_base_unsigned_256,
-        get_delta_amount_quote_unsigned_256, get_initial_liquidity_from_delta_quote,
-        get_next_sqrt_price_from_input,
+        get_delta_amount_base_unsigned_256, get_delta_amount_quote_unsigned_256,
+        get_initial_liquidity_from_delta_quote, get_next_sqrt_price_from_input,
     },
     safe_math::SafeMath,
     state::{LiquidityDistributionConfig, MigrationOption},
@@ -38,8 +37,8 @@ pub fn get_base_token_for_swap(
     sqrt_start_price: u128,
     sqrt_migration_price: u128,
     curve: &[LiquidityDistributionParameters],
-) -> Result<u64> {
-    let mut total_amount = 0u64;
+) -> Result<U256> {
+    let mut total_amount = U256::ZERO;
     for i in 0..curve.len() {
         let lower_sqrt_price = if i == 0 {
             sqrt_start_price
@@ -47,7 +46,7 @@ pub fn get_base_token_for_swap(
             curve[i - 1].sqrt_price
         };
         if curve[i].sqrt_price > sqrt_migration_price {
-            let delta_amount = get_delta_amount_base_unsigned(
+            let delta_amount = get_delta_amount_base_unsigned_256(
                 lower_sqrt_price,
                 sqrt_migration_price,
                 curve[i].liquidity,
@@ -56,7 +55,7 @@ pub fn get_base_token_for_swap(
             total_amount = total_amount.safe_add(delta_amount)?;
             break;
         } else {
-            let delta_amount = get_delta_amount_base_unsigned(
+            let delta_amount = get_delta_amount_base_unsigned_256(
                 lower_sqrt_price,
                 curve[i].sqrt_price,
                 curve[i].liquidity,

--- a/programs/virtual-curve/src/state/config.rs
+++ b/programs/virtual-curve/src/state/config.rs
@@ -5,7 +5,7 @@ use static_assertions::const_assert_eq;
 use crate::{
     constants::{
         fee::{FEE_DENOMINATOR, MAX_FEE_NUMERATOR},
-        MAX_CURVE_POINT, MAX_SQRT_PRICE, MAX_TOKEN_SUPPLY,
+        MAX_CURVE_POINT, MAX_SQRT_PRICE, SWAP_BUFFER_PERCENTAGE,
     },
     fee_math::get_fee_in_period,
     params::{
@@ -334,8 +334,8 @@ pub struct PoolConfig {
     pub quote_mint: Pubkey,
     /// Address to get the fee
     pub fee_claimer: Pubkey,
-    /// Owner of that config key
-    pub owner: Pubkey,
+    /// Address to receive extra base token after migration, in case token is fixed supply
+    pub leftover_receiver: Pubkey,
     /// Pool fee
     pub pool_fees: PoolFeesConfig,
     /// Collect fee mode
@@ -362,8 +362,10 @@ pub struct PoolConfig {
     pub creator_lp_percentage: u8,
     /// migration fee option
     pub migration_fee_option: u8,
+    /// flag to indicate whether token is dynamic supply (0) or fixed supply (1)
+    pub fixed_token_suppply_flag: u8,
     /// padding 0
-    pub _padding_0: [u8; 4],
+    pub _padding_0: [u8; 3],
     /// padding 1
     pub _padding_1: [u8; 8],
     /// swap base amount
@@ -376,8 +378,12 @@ pub struct PoolConfig {
     pub migration_sqrt_price: u128,
     /// locked vesting config
     pub locked_vesting_config: LockedVestingConfig,
+    /// pre migration token supply
+    pub pre_migration_token_supply: u64,
+    /// post migration token supply
+    pub post_migration_token_supply: u64,
     /// padding 2
-    pub _padding_2: [u128; 3],
+    pub _padding_2: [u128; 2],
     /// minimum price
     pub sqrt_start_price: u128,
     /// curve, only use 20 point firstly, we can extend that latter
@@ -400,7 +406,7 @@ impl PoolConfig {
         &mut self,
         quote_mint: &Pubkey,
         fee_claimer: &Pubkey,
-        owner: &Pubkey,
+        leftover_receiver: &Pubkey,
         pool_fees: &PoolFeeParameters,
         collect_fee_mode: u8,
         migration_option: u8,
@@ -419,12 +425,15 @@ impl PoolConfig {
         migration_base_threshold: u64,
         migration_sqrt_price: u128,
         sqrt_start_price: u128,
+        fixed_token_suppply_flag: u8,
+        pre_migration_token_supply: u64,
+        post_migration_token_supply: u64,
         curve: &Vec<LiquidityDistributionParameters>,
     ) {
         self.version = 0;
         self.quote_mint = *quote_mint;
         self.fee_claimer = *fee_claimer;
-        self.owner = *owner;
+        self.leftover_receiver = *leftover_receiver;
         self.pool_fees = pool_fees.to_pool_fees_config();
         self.collect_fee_mode = collect_fee_mode;
         self.migration_option = migration_option;
@@ -446,6 +455,9 @@ impl PoolConfig {
 
         self.locked_vesting_config = locked_vesting_params.to_locked_vesting_config();
         self.migration_fee_option = migration_fee_option;
+        self.fixed_token_suppply_flag = fixed_token_suppply_flag;
+        self.pre_migration_token_supply = pre_migration_token_supply;
+        self.post_migration_token_supply = post_migration_token_supply;
 
         let curve_length = curve.len();
         for i in 0..MAX_CURVE_POINT {
@@ -463,29 +475,55 @@ impl PoolConfig {
     pub fn total_amount_with_buffer(
         swap_base_amount: u64,
         migration_base_threshold: u64,
-    ) -> Result<u128> {
-        let total_amount: u128 =
-            u128::from(migration_base_threshold).safe_add(swap_base_amount.into())?;
-        let max_amount = 5u128.safe_mul(total_amount.into())?.safe_div(4)?;
-        Ok(max_amount)
-    }
-
-    pub fn get_max_supply(token_decimal: u8) -> Result<u128> {
-        let max_supply = 10u128
-            .pow(token_decimal.into())
-            .safe_mul(MAX_TOKEN_SUPPLY.into())?;
-        Ok(max_supply)
-    }
-
-    pub fn get_initial_base_supply(&self) -> Result<u64> {
-        let total_circulating_amount = PoolConfig::total_amount_with_buffer(
-            self.swap_base_amount,
-            self.migration_base_threshold,
-        )?;
-        let locked_vesting_params = self.locked_vesting_config.to_locked_vesting_params();
+        locked_vesting_params: &LockedVestingParams,
+        buffer_percentage: u8,
+    ) -> Result<u64> {
+        let swap_buffer = u128::from(swap_base_amount)
+            .safe_mul(buffer_percentage.into())?
+            .safe_div(100)?;
+        let swap_amount_with_buffer = swap_buffer.safe_add(swap_base_amount.into())?;
+        let total_circulating_amount =
+            swap_amount_with_buffer.safe_add(migration_base_threshold.into())?;
         let total_locked_vesting_amount = locked_vesting_params.get_total_amount()?;
         let total_amount = total_circulating_amount.safe_add(total_locked_vesting_amount.into())?;
         Ok(u64::try_from(total_amount).map_err(|_| PoolError::MathOverflow)?)
+    }
+
+    pub fn get_minimum_base_supply(&self) -> Result<u64> {
+        PoolConfig::total_amount_with_buffer(
+            self.swap_base_amount,
+            self.migration_base_threshold,
+            &self.locked_vesting_config.to_locked_vesting_params(),
+            SWAP_BUFFER_PERCENTAGE,
+        )
+    }
+
+    pub fn get_initial_base_supply(&self) -> Result<u64> {
+        if self.is_fixed_token_supply() {
+            Ok(self.pre_migration_token_supply)
+        } else {
+            self.get_minimum_base_supply()
+        }
+    }
+
+    fn get_max_burnable_amount_post_migration(&self) -> Result<u64> {
+        if self.is_fixed_token_supply() {
+            Ok(self
+                .pre_migration_token_supply
+                .safe_sub(self.post_migration_token_supply)?)
+        } else {
+            Ok(u64::MAX)
+        }
+    }
+
+    /// leftover is extra base token in base vault after curve is completed
+    pub fn get_burnable_amount_post_migration(&self, leftover: u64) -> Result<u64> {
+        let max_burnable_amount = self.get_max_burnable_amount_post_migration()?;
+        Ok(max_burnable_amount.min(leftover))
+    }
+
+    pub fn is_fixed_token_supply(&self) -> bool {
+        self.fixed_token_suppply_flag == 1
     }
 
     pub fn get_lp_distribution(&self, lp_amount: u64) -> Result<LiquidityDistributionU64> {

--- a/programs/virtual-curve/src/state/config.rs
+++ b/programs/virtual-curve/src/state/config.rs
@@ -365,7 +365,7 @@ pub struct PoolConfig {
     /// migration fee option
     pub migration_fee_option: u8,
     /// flag to indicate whether token is dynamic supply (0) or fixed supply (1)
-    pub fixed_token_suppply_flag: u8,
+    pub fixed_token_supply_flag: u8,
     /// padding 0
     pub _padding_0: [u8; 3],
     /// padding 1
@@ -404,7 +404,7 @@ pub struct LiquidityDistributionConfig {
 }
 
 impl LiquidityDistributionConfig {
-    pub fn to_liquidity_distribution_paramters(&self) -> LiquidityDistributionParameters {
+    pub fn to_liquidity_distribution_parameters(&self) -> LiquidityDistributionParameters {
         LiquidityDistributionParameters {
             sqrt_price: self.sqrt_price,
             liquidity: self.liquidity,
@@ -436,7 +436,7 @@ impl PoolConfig {
         migration_base_threshold: u64,
         migration_sqrt_price: u128,
         sqrt_start_price: u128,
-        fixed_token_suppply_flag: u8,
+        fixed_token_supply_flag: u8,
         pre_migration_token_supply: u64,
         post_migration_token_supply: u64,
         curve: &Vec<LiquidityDistributionParameters>,
@@ -466,7 +466,7 @@ impl PoolConfig {
 
         self.locked_vesting_config = locked_vesting_params.to_locked_vesting_config();
         self.migration_fee_option = migration_fee_option;
-        self.fixed_token_suppply_flag = fixed_token_suppply_flag;
+        self.fixed_token_supply_flag = fixed_token_supply_flag;
         self.pre_migration_token_supply = pre_migration_token_supply;
         self.post_migration_token_supply = post_migration_token_supply;
 
@@ -524,7 +524,7 @@ impl PoolConfig {
                 if self.curve[i].liquidity == 0 {
                     break;
                 }
-                curve.push(self.curve[i].to_liquidity_distribution_paramters());
+                curve.push(self.curve[i].to_liquidity_distribution_parameters());
             }
             let swap_amount_with_buffer = PoolConfig::get_swap_amount_with_buffer(
                 self.swap_base_amount,
@@ -556,7 +556,7 @@ impl PoolConfig {
     }
 
     pub fn is_fixed_token_supply(&self) -> bool {
-        self.fixed_token_suppply_flag == 1
+        self.fixed_token_supply_flag == 1
     }
 
     pub fn get_lp_distribution(&self, lp_amount: u64) -> Result<LiquidityDistributionU64> {

--- a/programs/virtual-curve/src/state/virtual_pool.rs
+++ b/programs/virtual-curve/src/state/virtual_pool.rs
@@ -118,8 +118,10 @@ pub struct VirtualPool {
     pub is_procotol_withdraw_surplus: u8,
     /// migration progress
     pub migration_progress: u8,
+    /// is withdraw leftover
+    pub is_withdraw_leftover: u8,
     /// padding
-    pub _padding_0: [u8; 3],
+    pub _padding_0: [u8; 2],
     /// pool metrics
     pub metrics: PoolMetrics,
     /// The time curve is finished
@@ -551,6 +553,10 @@ impl VirtualPool {
 
     pub fn update_protocol_withdraw_surplus(&mut self) {
         self.is_procotol_withdraw_surplus = 1;
+    }
+
+    pub fn update_withdraw_leftover(&mut self) {
+        self.is_withdraw_leftover = 1;
     }
 
     pub fn get_migration_progress(&self) -> Result<MigrationProgress> {

--- a/tests/claim_and_lock_lp_on_meteora_damm.tests.ts
+++ b/tests/claim_and_lock_lp_on_meteora_damm.tests.ts
@@ -63,11 +63,18 @@ async function createPartnerConfig(
 
   const curves = [];
 
-  for (let i = 1; i <= 20; i++) {
-    curves.push({
-      sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-      liquidity: U64_MAX.shln(30 + i),
-    });
+  for (let i = 1; i <= 16; i++) {
+    if (i == 16) {
+      curves.push({
+        sqrtPrice: MAX_SQRT_PRICE,
+        liquidity: U64_MAX.shln(30 + i),
+      });
+    } else {
+      curves.push({
+        sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+        liquidity: U64_MAX.shln(30 + i),
+      });
+    }
   }
 
   const instructionParams: ConfigParameters = {
@@ -94,12 +101,13 @@ async function createPartnerConfig(
       cliffUnlockAmount: new BN(0),
     },
     migrationFeeOption: 0,
-    padding: [0, 0, 0, 0, 0, 0, 0],
+    tokenSupply: null,
+    padding: [],
     curve: curves,
   };
   const params: CreateConfigParams = {
     payer,
-    owner,
+    leftoverReceiver: owner,
     feeClaimer,
     quoteMint: NATIVE_MINT,
     instructionParams,

--- a/tests/claim_lp_on_meteora_damm.tests.ts
+++ b/tests/claim_lp_on_meteora_damm.tests.ts
@@ -74,11 +74,18 @@ describe("Claim lp on meteora dammm", () => {
 
         const curves = [];
 
-        for (let i = 1; i <= 20; i++) {
-            curves.push({
-                sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-                liquidity: U64_MAX.shln(30 + i),
-            });
+        for (let i = 1; i <= 16; i++) {
+            if (i == 16) {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE,
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            } else {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            }
         }
 
         const instructionParams: ConfigParameters = {

--- a/tests/create_locker.tests.ts
+++ b/tests/create_locker.tests.ts
@@ -68,11 +68,18 @@ describe("Create locker", () => {
 
             const curves = [];
 
-            for (let i = 1; i <= 20; i++) {
-                curves.push({
-                    sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-                    liquidity: U64_MAX.shln(30 + i),
-                });
+            for (let i = 1; i <= 16; i++) {
+                if (i == 16) {
+                    curves.push({
+                        sqrtPrice: MAX_SQRT_PRICE,
+                        liquidity: U64_MAX.shln(30 + i),
+                    });
+                } else {
+                    curves.push({
+                        sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+                        liquidity: U64_MAX.shln(30 + i),
+                    });
+                }
             }
 
             const instructionParams: ConfigParameters = {
@@ -219,11 +226,18 @@ describe("Create locker", () => {
 
             const curves = [];
 
-            for (let i = 1; i <= 20; i++) {
-                curves.push({
-                    sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-                    liquidity: U64_MAX.shln(30 + i),
-                });
+            for (let i = 1; i <= 16; i++) {
+                if (i == 16) {
+                    curves.push({
+                        sqrtPrice: MAX_SQRT_PRICE,
+                        liquidity: U64_MAX.shln(30 + i),
+                    });
+                } else {
+                    curves.push({
+                        sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+                        liquidity: U64_MAX.shln(30 + i),
+                    });
+                }
             }
 
             const instructionParams: ConfigParameters = {

--- a/tests/create_locker.tests.ts
+++ b/tests/create_locker.tests.ts
@@ -25,7 +25,6 @@ import { getVirtualPool } from "./utils/fetcher";
 import { NATIVE_MINT } from "@solana/spl-token";
 
 import { createMeteoraDammV2Metadata, MigrateMeteoraDammV2Params, migrateToDammV2 } from "./instructions/dammV2Migration";
-import { expect } from "chai";
 
 describe("Create locker", () => {
     describe("Create locker for spl-token", () => {
@@ -100,12 +99,13 @@ describe("Create locker", () => {
                     cliffUnlockAmount: new BN(1_000_000_000),
                 },
                 migrationFeeOption: 0,
-                padding: [0, 0, 0, 0, 0, 0, 0],
+                tokenSupply: null,
+                padding: [],
                 curve: curves,
             };
             const params: CreateConfigParams = {
                 payer: partner,
-                owner: partner.publicKey,
+                leftoverReceiver: partner.publicKey,
                 feeClaimer: partner.publicKey,
                 quoteMint: NATIVE_MINT,
                 instructionParams,
@@ -250,12 +250,13 @@ describe("Create locker", () => {
                     cliffUnlockAmount: new BN(1_000_000_000),
                 },
                 migrationFeeOption: 0,
-                padding: [0, 0, 0, 0, 0, 0, 0],
+                tokenSupply: null,
+                padding: [],
                 curve: curves,
             };
             const params: CreateConfigParams = {
                 payer: partner,
-                owner: partner.publicKey,
+                leftoverReceiver: partner.publicKey,
                 feeClaimer: partner.publicKey,
                 quoteMint: NATIVE_MINT,
                 instructionParams,

--- a/tests/create_pool_with_token2022.tests.ts
+++ b/tests/create_pool_with_token2022.tests.ts
@@ -110,12 +110,13 @@ describe("Create pool with token2022", () => {
                 cliffUnlockAmount: new BN(0),
             },
             migrationFeeOption: 0,
-            padding: [0, 0, 0, 0, 0, 0, 0],
+            tokenSupply: null,
+            padding: [],
             curve: curves,
         };
         const params: CreateConfigParams = {
             payer: partner,
-            owner: partner.publicKey,
+            leftoverReceiver: partner.publicKey,
             feeClaimer: partner.publicKey,
             quoteMint: NATIVE_MINT,
             instructionParams,

--- a/tests/create_pool_with_token2022.tests.ts
+++ b/tests/create_pool_with_token2022.tests.ts
@@ -79,11 +79,18 @@ describe("Create pool with token2022", () => {
 
         const curves = [];
 
-        for (let i = 1; i <= 20; i++) {
-            curves.push({
-                sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-                liquidity: U64_MAX.shln(30 + i),
-            });
+        for (let i = 1; i <= 16; i++) {
+            if (i == 16) {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE,
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            } else {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            }
         }
 
         const instructionParams: ConfigParameters = {

--- a/tests/create_virtual_pool_metadata.tests.ts
+++ b/tests/create_virtual_pool_metadata.tests.ts
@@ -58,11 +58,18 @@ describe("Create virtual pool metadata", () => {
 
         const curves = [];
 
-        for (let i = 1; i <= 20; i++) {
-            curves.push({
-                sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-                liquidity: U64_MAX.shln(30 + i),
-            });
+        for (let i = 1; i <= 16; i++) {
+            if (i == 16) {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE,
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            } else {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            }
         }
 
         const instructionParams: ConfigParameters = {

--- a/tests/design_pumpfun_curve.tests.ts
+++ b/tests/design_pumpfun_curve.tests.ts
@@ -1,0 +1,468 @@
+import BN, { BN } from "bn.js";
+import { BanksClient, ProgramTestContext, start } from "solana-bankrun";
+import Decimal from "decimal.js";
+import {
+    ConfigParameters,
+    createConfig,
+    CreateConfigParams,
+    createLocker,
+    createMeteoraMetadata,
+    createPoolWithSplToken,
+    LiquidityDistributionParameters,
+    MigrateMeteoraParams,
+    migrateToMeteoraDamm,
+    swap,
+    SwapParams,
+} from "./instructions";
+import { VirtualCurveProgram } from "./utils/types";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { createDammConfig, fundSol, getMint, startTest } from "./utils";
+import {
+    createVirtualCurveProgram,
+    derivePoolAuthority,
+    MAX_SQRT_PRICE,
+} from "./utils";
+import { getConfig, getVirtualPool } from "./utils/fetcher";
+
+import { expect } from "chai";
+import { createToken, mintSplTokenTo } from "./utils/token";
+
+function getDeltaAmountBase(lowerSqrtPrice: BN, upperSqrtPrice: BN, liquidity: BN): BN {
+    let numerator = liquidity.mul(upperSqrtPrice.sub(lowerSqrtPrice));
+    let denominator = lowerSqrtPrice.mul(upperSqrtPrice);
+    return numerator.add(denominator).sub(new BN(1)).div(denominator);
+}
+function getBaseTokenForSwap(
+    sqrtStartPrice: BN,
+    sqrtMigrationPrice: BN,
+    curve: Array<LiquidityDistributionParameters>,
+): BN {
+    let totalAmount = new BN(0);
+    for (let i = 0; i < curve.length; i++) {
+        let lowerSqrtPrice = i == 0 ? sqrtStartPrice : curve[i - 1].sqrtPrice;
+        if (curve[i].sqrtPrice > sqrtMigrationPrice) {
+            let deltaAmount = getDeltaAmountBase(
+                lowerSqrtPrice,
+                sqrtMigrationPrice,
+                curve[i].liquidity,
+            );
+            totalAmount = totalAmount.add(deltaAmount);
+            break;
+        } else {
+            let deltaAmount = getDeltaAmountBase(
+                lowerSqrtPrice,
+                curve[i].sqrtPrice,
+                curve[i].liquidity,
+            );
+            totalAmount = totalAmount.add(deltaAmount);
+        }
+    }
+    return totalAmount;
+}
+
+function getBaseTokenForMigration(sqrtMigrationPrice: BN, migrationQuoteThreshold: BN): BN {
+    let price = sqrtMigrationPrice.mul(sqrtMigrationPrice);
+    let base = migrationQuoteThreshold.shln(128).div(price);
+    return base;
+}
+
+// Original formula: price = (sqrtPrice >> 64)^2 * 10^(tokenADecimal - tokenBDecimal)
+// Reverse formula: sqrtPrice = sqrt(price / 10^(tokenADecimal - tokenBDecimal)) << 64
+export const getSqrtPriceFromPrice = (
+    price: string,
+    tokenADecimal: number,
+    tokenBDecimal: number
+): BN => {
+    const decimalPrice = new Decimal(price);
+    const adjustedByDecimals = decimalPrice.div(
+        new Decimal(10 ** (tokenADecimal - tokenBDecimal))
+    );
+    const sqrtValue = Decimal.sqrt(adjustedByDecimals);
+    const sqrtValueQ64 = sqrtValue.mul(Decimal.pow(2, 64));
+    return new BN(sqrtValueQ64.floor().toFixed());
+};
+
+export const getPriceFromSqrtPrice = (
+    sqrtPrice: BN,
+    tokenADecimal: number,
+    tokenBDecimal: number
+): Decimal => {
+    const decimalSqrtPrice = new Decimal(sqrtPrice.toString());
+    const price = decimalSqrtPrice
+        .mul(decimalSqrtPrice)
+        .mul(new Decimal(10 ** (tokenADecimal - tokenBDecimal)))
+        .div(Decimal.pow(2, 128));
+
+    return price;
+};
+
+function designPumfunCurve(
+    totalTokenSupply: number,
+    percentageSupplyOnMigration: number,
+    percentageSupplyVesting: number,
+    frequency: number,
+    numberOfPeriod: number,
+    startPrice: Decimal,
+    migrationPrice: Decimal,
+    tokenBaseDecimal: number,
+    tokenQuoteDecimal: number,
+): ConfigParameters {
+    let totalSupply = new BN(totalTokenSupply).mul(new BN(10).pow(new BN(tokenBaseDecimal)));
+    let baseDecimalFactor = new Decimal(10 ** tokenBaseDecimal);
+    let quoteDecimalFactor = new Decimal(10 ** tokenQuoteDecimal);
+    let preMigrationTokenSupply = totalSupply;
+    let postMigrationTokenSupply = totalSupply;
+    let migrationSupply = totalSupply.mul(new BN(percentageSupplyOnMigration)).div(new BN(100));
+    let lockedVestingAmount = totalSupply.mul(new BN(percentageSupplyVesting)).div(new BN(100));
+    let amountPerPeriod = numberOfPeriod == 0 ? new BN(0) : lockedVestingAmount.div(new BN(numberOfPeriod));
+    lockedVestingAmount = amountPerPeriod.mul(new BN(numberOfPeriod));
+
+    let sqrtStartPrice = getSqrtPriceFromPrice(startPrice, tokenBaseDecimal, tokenQuoteDecimal);
+    let migrationSqrtPrice = getSqrtPriceFromPrice(migrationPrice, tokenBaseDecimal, tokenQuoteDecimal);
+    let priceDelta = migrationSqrtPrice.sub(sqrtStartPrice);
+
+    let migrationQuoteThresholdFloat = migrationPrice.mul(new Decimal(migrationSupply.toString())).mul(quoteDecimalFactor).div(baseDecimalFactor).floor();
+    let migrationQuoteThreshold = new BN(migrationQuoteThresholdFloat.toString());
+    let liquidity = migrationQuoteThreshold.shln(128).div(priceDelta);
+    let curves = [
+        {
+            sqrtPrice: migrationSqrtPrice,
+            liquidity,
+        },
+        {
+            sqrtPrice: MAX_SQRT_PRICE,
+            liquidity: new BN(1),
+        }
+    ];
+
+    // reverse to get amount on swap
+    let maxSwapAmount = getBaseTokenForSwap(sqrtStartPrice, MAX_SQRT_PRICE, curves);
+    let migrationAmount = getBaseTokenForMigration(migrationSqrtPrice, migrationQuoteThreshold);
+    let cliffUnlockAmount = percentageSupplyVesting == 0 ? new BN(0) : totalSupply.sub(maxSwapAmount).sub(lockedVestingAmount).sub(migrationAmount);
+
+    console.log("migrationAmount: ", migrationAmount.toString());
+    console.log("maxSwapAmount: ", maxSwapAmount.toString());
+    console.log("migrationQuoteThreshold: ", migrationQuoteThreshold.toString());
+
+    const instructionParams: ConfigParameters = {
+        poolFees: {
+            baseFee: {
+                cliffFeeNumerator: new BN(2_500_000),
+                numberOfPeriod: 0,
+                reductionFactor: new BN(0),
+                periodFrequency: new BN(0),
+                feeSchedulerMode: 0,
+            },
+            dynamicFee: null,
+        },
+        activationType: 0,
+        collectFeeMode: 1,
+        migrationOption: 0, /// damm v1
+        tokenType: 0, // spl_token
+        tokenDecimal: tokenBaseDecimal,
+        migrationQuoteThreshold,
+        partnerLpPercentage: 0,
+        creatorLpPercentage: 0,
+        partnerLockedLpPercentage: 100,
+        creatorLockedLpPercentage: 0,
+        sqrtStartPrice,
+        lockedVesting: {
+            amountPerPeriod: amountPerPeriod,
+            cliffDurationFromMigrationTime: new BN(0),
+            frequency: new BN(frequency),
+            numberOfPeriod: new BN(numberOfPeriod),
+            cliffUnlockAmount,
+        },
+        migrationFeeOption: 0,
+        tokenSupply: {
+            preMigrationTokenSupply,
+            postMigrationTokenSupply,
+        },
+        padding: [],
+        curve: curves,
+    };
+    return instructionParams;
+}
+
+
+
+function designPumfunCurveWihoutLockVesting(
+    totalTokenSupply: number,
+    percentageSupplyOnMigration: number,
+    startPrice: Decimal,
+    tokenBaseDecimal: number,
+    tokenQuoteDecimal: number,
+): ConfigParameters {
+    let totalSupply = new BN(totalTokenSupply).mul(new BN(10).pow(new BN(tokenBaseDecimal)));
+    let baseDecimalFactor = new Decimal(10 ** tokenBaseDecimal);
+    let quoteDecimalFactor = new Decimal(10 ** tokenQuoteDecimal);
+    let preMigrationTokenSupply = totalSupply;
+    let postMigrationTokenSupply = totalSupply;
+    let migrationSupply = totalSupply.mul(new BN(percentageSupplyOnMigration)).div(new BN(100));
+    let swapSupply = totalSupply.sub(migrationSupply);
+
+    let sqrtStartPrice = getSqrtPriceFromPrice(startPrice, tokenBaseDecimal, tokenQuoteDecimal);
+    let migrationSqrtPrice = sqrtStartPrice.mul(swapSupply).div(migrationSupply); // magic formula
+    migrationSqrtPrice = migrationSqrtPrice.sub(new BN(1));
+    let priceDelta = migrationSqrtPrice.sub(sqrtStartPrice);
+
+    let migrationPrice = getPriceFromSqrtPrice(migrationSqrtPrice, tokenBaseDecimal, tokenQuoteDecimal);
+    let migrationQuoteThresholdFloat = migrationPrice.mul(new Decimal(migrationSupply.toString())).mul(quoteDecimalFactor).div(baseDecimalFactor).floor();
+
+    let migrationQuoteThreshold = new BN(migrationQuoteThresholdFloat.toString());
+
+
+    let liquidity = migrationQuoteThreshold.shln(128).div(priceDelta);
+    let curves = [
+        {
+            sqrtPrice: migrationSqrtPrice,
+            liquidity,
+        },
+        {
+            sqrtPrice: MAX_SQRT_PRICE,
+            liquidity: new BN(1),
+        }
+    ];
+
+    const instructionParams: ConfigParameters = {
+        poolFees: {
+            baseFee: {
+                cliffFeeNumerator: new BN(2_500_000),
+                numberOfPeriod: 0,
+                reductionFactor: new BN(0),
+                periodFrequency: new BN(0),
+                feeSchedulerMode: 0,
+            },
+            dynamicFee: null,
+        },
+        activationType: 0,
+        collectFeeMode: 1,
+        migrationOption: 0, /// damm v1
+        tokenType: 0, // spl_token
+        tokenDecimal: tokenBaseDecimal,
+        migrationQuoteThreshold,
+        partnerLpPercentage: 0,
+        creatorLpPercentage: 0,
+        partnerLockedLpPercentage: 100,
+        creatorLockedLpPercentage: 0,
+        sqrtStartPrice,
+        lockedVesting: {
+            amountPerPeriod: new BN(0),
+            cliffDurationFromMigrationTime: new BN(0),
+            frequency: new BN(0),
+            numberOfPeriod: new BN(0),
+            cliffUnlockAmount: new BN(0),
+        },
+        migrationFeeOption: 0,
+        tokenSupply: {
+            preMigrationTokenSupply,
+            postMigrationTokenSupply,
+        },
+        padding: [],
+        curve: curves,
+    };
+    return instructionParams;
+}
+
+describe("Design pumpfun curve", () => {
+    let context: ProgramTestContext;
+    let admin: Keypair;
+    let operator: Keypair;
+    let partner: Keypair;
+    let user: Keypair;
+    let poolCreator: Keypair;
+    let program: VirtualCurveProgram;
+
+    before(async () => {
+        context = await startTest();
+        admin = context.payer;
+        operator = Keypair.generate();
+        partner = Keypair.generate();
+        user = Keypair.generate();
+        poolCreator = Keypair.generate();
+        const receivers = [
+            operator.publicKey,
+            partner.publicKey,
+            user.publicKey,
+            poolCreator.publicKey,
+        ];
+        await fundSol(context.banksClient, admin, receivers);
+        program = createVirtualCurveProgram();
+
+
+
+    });
+
+    it("Design pumpfun curve with lock vesting", async () => {
+        let totalTokenSupply = 1_000_000_000; // 1 billion
+        let percentageSupplyOnMigration = 10; // 10%;
+        let percentageSupplyVesting = 40; // 40%
+        let frequency = 3600; // each 1 hour
+        let numberOfPeriod = 100;
+        let startPrice = new Decimal("0.0005"); // 500k market cap
+        let migrationPrice = new Decimal("0.005"); // 5M market cap
+        let tokenBaseDecimal = 6;
+        let tokenQuoteDecimal = 9;
+        let quoteMint = await createToken(context.banksClient, admin, admin.publicKey, tokenQuoteDecimal);
+        let instructionParams = designPumfunCurve(
+            totalTokenSupply,
+            percentageSupplyOnMigration,
+            percentageSupplyVesting,
+            frequency,
+            numberOfPeriod,
+            startPrice,
+            migrationPrice,
+            tokenBaseDecimal,
+            tokenQuoteDecimal,
+        );
+        const params: CreateConfigParams = {
+            payer: partner,
+            leftoverReceiver: partner.publicKey,
+            feeClaimer: partner.publicKey,
+            quoteMint,
+            instructionParams,
+        };
+        let config = await createConfig(context.banksClient, program, params);
+        await mintSplTokenTo(context.banksClient, user, quoteMint, admin, user.publicKey, instructionParams.migrationQuoteThreshold.toNumber());
+        await fullFlow(context.banksClient, program, config, poolCreator, user, admin, quoteMint);
+    });
+
+    it("Design pumpfun curve without lock vesting with leftover", async () => {
+        /// NOTE, this case with have leftover, 
+        // because percentageSupplyOnMigration and migrationPrice is fixed -> migrationQuoteThreshold is fixed
+        // startPrice is fixed, migrationPrice is fixed and migrationQuoteThreshold is fixed -> swapAmount is fixed
+        let totalTokenSupply = 1_000_000_000; // 1 billion
+        let percentageSupplyOnMigration = 10; // 10%;
+        let percentageSupplyVesting = 0; // 40%
+        let frequency = 0; // each 1 hour
+        let numberOfPeriod = 0;
+        let startPrice = new Decimal("0.0005"); // 500k market cap
+        let migrationPrice = new Decimal("0.005"); // 5M market cap
+        let tokenBaseDecimal = 6;
+        let tokenQuoteDecimal = 9;
+        let quoteMint = await createToken(context.banksClient, admin, admin.publicKey, tokenQuoteDecimal);
+        let instructionParams = designPumfunCurve(
+            totalTokenSupply,
+            percentageSupplyOnMigration,
+            percentageSupplyVesting,
+            frequency,
+            numberOfPeriod,
+            startPrice,
+            migrationPrice,
+            tokenBaseDecimal,
+            tokenQuoteDecimal,
+        );
+        const params: CreateConfigParams = {
+            payer: partner,
+            leftoverReceiver: partner.publicKey,
+            feeClaimer: partner.publicKey,
+            quoteMint,
+            instructionParams,
+        };
+        let config = await createConfig(context.banksClient, program, params);
+        await mintSplTokenTo(context.banksClient, user, quoteMint, admin, user.publicKey, instructionParams.migrationQuoteThreshold.toNumber());
+        await fullFlow(context.banksClient, program, config, poolCreator, user, admin, quoteMint);
+    });
+
+
+    it("Design pumpfun curve without leftover", async () => {
+        let totalTokenSupply = 1_000_000_000; // 1 billion
+        let percentageSupplyOnMigration = 10; // 10%;
+        let startPrice = new Decimal("0.0005"); // 500k market cap
+        let tokenBaseDecimal = 6;
+        let tokenQuoteDecimal = 9;
+        let quoteMint = await createToken(context.banksClient, admin, admin.publicKey, tokenQuoteDecimal);
+        let instructionParams = designPumfunCurveWihoutLockVesting(
+            totalTokenSupply,
+            percentageSupplyOnMigration,
+            startPrice,
+            tokenBaseDecimal,
+            tokenQuoteDecimal,
+        );
+        const params: CreateConfigParams = {
+            payer: partner,
+            leftoverReceiver: partner.publicKey,
+            feeClaimer: partner.publicKey,
+            quoteMint,
+            instructionParams,
+        };
+        let config = await createConfig(context.banksClient, program, params);
+        await mintSplTokenTo(context.banksClient, user, quoteMint, admin, user.publicKey, instructionParams.migrationQuoteThreshold.toNumber());
+        await fullFlow(context.banksClient, program, config, poolCreator, user, admin, quoteMint);
+    });
+});
+
+
+async function fullFlow(
+    banksClient: BanksClient,
+    program: VirtualCurveProgram,
+    config: PublicKey,
+    poolCreator: Keypair,
+    user: Keypair,
+    admin: Keypair,
+    quoteMint: PublicKey,
+) {
+    // create pool
+    let virtualPool = await createPoolWithSplToken(banksClient, program, {
+        payer: poolCreator,
+        quoteMint,
+        config,
+        instructionParams: {
+            name: "test token spl",
+            symbol: "TEST",
+            uri: "abc.com",
+        },
+    });
+    let virtualPoolState = await getVirtualPool(
+        banksClient,
+        program,
+        virtualPool
+    );
+
+    let configState = await getConfig(banksClient, program, config);
+
+    // swap
+    const params: SwapParams = {
+        config,
+        payer: user,
+        pool: virtualPool,
+        inputTokenMint: quoteMint,
+        outputTokenMint: virtualPoolState.baseMint,
+        amountIn: configState.migrationQuoteThreshold,
+        minimumAmountOut: new BN(0),
+        referralTokenAccount: null,
+    };
+    await swap(banksClient, program, params);
+
+    // migrate
+    const poolAuthority = derivePoolAuthority();
+    let dammConfig = await createDammConfig(
+        banksClient,
+        admin,
+        poolAuthority
+    );
+    const migrationParams: MigrateMeteoraParams = {
+        payer: admin,
+        virtualPool,
+        dammConfig,
+    };
+    await createMeteoraMetadata(banksClient, program, {
+        payer: admin,
+        virtualPool,
+        config,
+    });
+
+    if (configState.lockedVestingConfig.frequency.toNumber() != 0) {
+        await createLocker(banksClient, program, {
+            payer: admin,
+            virtualPool,
+        });
+    }
+    await migrateToMeteoraDamm(banksClient, program, migrationParams);
+    const baseMintData = (
+        await getMint(banksClient, virtualPoolState.baseMint)
+    );
+
+    expect(baseMintData.supply.toString()).eq(configState.postMigrationTokenSupply.toString());
+
+}

--- a/tests/fee_swap.tests.ts
+++ b/tests/fee_swap.tests.ts
@@ -58,11 +58,18 @@ describe("Fee Swap test", () => {
 
       const curves = [];
 
-      for (let i = 1; i <= 20; i++) {
-        curves.push({
-          sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-          liquidity: U64_MAX.shln(30 + i),
-        });
+      for (let i = 1; i <= 16; i++) {
+        if (i == 16) {
+          curves.push({
+            sqrtPrice: MAX_SQRT_PRICE,
+            liquidity: U64_MAX.shln(30 + i),
+          });
+        } else {
+          curves.push({
+            sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+            liquidity: U64_MAX.shln(30 + i),
+          });
+        }
       }
 
       const instructionParams: ConfigParameters = {
@@ -376,11 +383,18 @@ describe("Fee Swap test", () => {
 
       const curves = [];
 
-      for (let i = 1; i <= 20; i++) {
-        curves.push({
-          sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-          liquidity: U64_MAX.shln(30 + i),
-        });
+      for (let i = 1; i <= 16; i++) {
+        if (i == 16) {
+          curves.push({
+            sqrtPrice: MAX_SQRT_PRICE,
+            liquidity: U64_MAX.shln(30 + i),
+          });
+        } else {
+          curves.push({
+            sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+            liquidity: U64_MAX.shln(30 + i),
+          });
+        }
       }
 
       const instructionParams: ConfigParameters = {

--- a/tests/fee_swap.tests.ts
+++ b/tests/fee_swap.tests.ts
@@ -89,12 +89,13 @@ describe("Fee Swap test", () => {
           cliffUnlockAmount: new BN(0),
         },
         migrationFeeOption: 0,
-        padding: [0, 0, 0, 0, 0, 0, 0],
+        tokenSupply: null,
+        padding: [],
         curve: curves,
       };
       const params: CreateConfigParams = {
         payer: partner,
-        owner: partner.publicKey,
+        leftoverReceiver: partner.publicKey,
         feeClaimer: partner.publicKey,
         quoteMint: NATIVE_MINT,
         instructionParams,
@@ -406,12 +407,13 @@ describe("Fee Swap test", () => {
           cliffUnlockAmount: new BN(0),
         },
         migrationFeeOption: 0,
-        padding: [0, 0, 0, 0, 0, 0, 0],
+        tokenSupply: null,
+        padding: [],
         curve: curves,
       };
       const params: CreateConfigParams = {
         payer: partner,
-        owner: partner.publicKey,
+        leftoverReceiver: partner.publicKey,
         feeClaimer: partner.publicKey,
         quoteMint: NATIVE_MINT,
         instructionParams,

--- a/tests/fixed_token_supply.tests.ts
+++ b/tests/fixed_token_supply.tests.ts
@@ -3,7 +3,6 @@ import { ProgramTestContext } from "solana-bankrun";
 import {
     BaseFee,
     ConfigParameters,
-    createClaimFeeOperator,
     createConfig,
     CreateConfigParams,
     createPoolWithSplToken,
@@ -27,7 +26,7 @@ import { NATIVE_MINT } from "@solana/spl-token";
 import { createMeteoraDammV2Metadata, MigrateMeteoraDammV2Params, migrateToDammV2 } from "./instructions/dammV2Migration";
 import { expect } from "chai";
 
-describe.only("Fixed token supply", () => {
+describe("Fixed token supply", () => {
     let context: ProgramTestContext;
     let admin: Keypair;
     let operator: Keypair;

--- a/tests/fixed_token_supply.tests.ts
+++ b/tests/fixed_token_supply.tests.ts
@@ -69,11 +69,18 @@ describe("Fixed token supply", () => {
 
         const curves = [];
 
-        for (let i = 1; i <= 20; i++) {
-            curves.push({
-                sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-                liquidity: U64_MAX.shln(30 + i),
-            });
+        for (let i = 1; i <= 16; i++) {
+            if (i == 16) {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE,
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            } else {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            }
         }
 
         const instructionParams: ConfigParameters = {

--- a/tests/full_flow_with_sol.tests.ts
+++ b/tests/full_flow_with_sol.tests.ts
@@ -90,11 +90,19 @@ describe("Full flow with spl-token", () => {
 
     const curves = [];
 
-    for (let i = 1; i <= 20; i++) {
-      curves.push({
-        sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-        liquidity: U64_MAX.shln(30 + i),
-      });
+    for (let i = 1; i <= 16; i++) {
+      if (i == 16) {
+        curves.push({
+          sqrtPrice: MAX_SQRT_PRICE,
+          liquidity: U64_MAX.shln(30 + i),
+        });
+      } else {
+        curves.push({
+          sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+          liquidity: U64_MAX.shln(30 + i),
+        });
+      }
+
     }
 
     const instructionParams: ConfigParameters = {

--- a/tests/full_flow_with_sol.tests.ts
+++ b/tests/full_flow_with_sol.tests.ts
@@ -121,12 +121,13 @@ describe("Full flow with spl-token", () => {
         cliffUnlockAmount: new BN(0),
       },
       migrationFeeOption: 0,
-      padding: [0, 0, 0, 0, 0, 0, 0],
+      tokenSupply: null,
+      padding: [],
       curve: curves,
     };
     const params: CreateConfigParams = {
       payer: partner,
-      owner: partner.publicKey,
+      leftoverReceiver: partner.publicKey,
       feeClaimer: partner.publicKey,
       quoteMint: NATIVE_MINT,
       instructionParams,

--- a/tests/migrate_to_damm_v2.tests.ts
+++ b/tests/migrate_to_damm_v2.tests.ts
@@ -79,11 +79,18 @@ describe("Migrate to damm v2", () => {
 
         const curves = [];
 
-        for (let i = 1; i <= 20; i++) {
-            curves.push({
-                sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
-                liquidity: U64_MAX.shln(30 + i),
-            });
+        for (let i = 1; i <= 16; i++) {
+            if (i == 16) {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE,
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            } else {
+                curves.push({
+                    sqrtPrice: MAX_SQRT_PRICE.muln(i * 5).divn(100),
+                    liquidity: U64_MAX.shln(30 + i),
+                });
+            }
         }
 
         const instructionParams: ConfigParameters = {

--- a/tests/migrate_to_damm_v2.tests.ts
+++ b/tests/migrate_to_damm_v2.tests.ts
@@ -110,12 +110,13 @@ describe("Migrate to damm v2", () => {
                 cliffUnlockAmount: new BN(0),
             },
             migrationFeeOption: 0,
-            padding: [0, 0, 0, 0, 0, 0, 0],
+            tokenSupply: null,
+            padding: [],
             curve: curves,
         };
         const params: CreateConfigParams = {
             payer: partner,
-            owner: partner.publicKey,
+            leftoverReceiver: partner.publicKey,
             feeClaimer: partner.publicKey,
             quoteMint: NATIVE_MINT,
             instructionParams,

--- a/tests/simulate_cu_swap.tests.ts
+++ b/tests/simulate_cu_swap.tests.ts
@@ -35,7 +35,7 @@ describe("Simulate CU swap", () => {
 
   it("Simulate CU Swap", async () => {
     const result = [];
-    for (let curve_size = 1; curve_size <= 20; curve_size++) {
+    for (let curve_size = 1; curve_size <= 16; curve_size++) {
       let curves = [];
       for (let i = 1; i <= curve_size; i++) {
         curves.push({

--- a/tests/simulate_cu_swap.tests.ts
+++ b/tests/simulate_cu_swap.tests.ts
@@ -78,12 +78,13 @@ describe("Simulate CU swap", () => {
           cliffUnlockAmount: new BN(0),
         },
         migrationFeeOption: 0,
-        padding: [0, 0, 0, 0, 0, 0, 0],
+        tokenSupply: null,
+        padding: [],
         curve: curves,
       };
       const createConfigParams: CreateConfigParams = {
         payer: user,
-        owner: user.publicKey,
+        leftoverReceiver: user.publicKey,
         feeClaimer: user.publicKey,
         quoteMint: NATIVE_MINT,
         instructionParams,

--- a/tests/utils/token.ts
+++ b/tests/utils/token.ts
@@ -1,0 +1,166 @@
+import {
+  AccountLayout,
+  createAssociatedTokenAccountInstruction,
+  createInitializeMint2Instruction,
+  createInitializeMintInstruction,
+  createMintToInstruction,
+  createSyncNativeInstruction,
+  ExtensionType,
+  getAssociatedTokenAddressSync,
+  getMintLen,
+  MINT_SIZE,
+  MintLayout,
+  NATIVE_MINT,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import BN from "bn.js";
+import { BanksClient } from "solana-bankrun";
+// import { DECIMALS } from "./constants";
+// const rawAmount = 1_000_000 * 10 ** DECIMALS; // 1 millions
+
+export async function getOrCreateAssociatedTokenAccount(
+  banksClient: BanksClient,
+  payer: Keypair,
+  mint: PublicKey,
+  owner: PublicKey,
+  tokenProgram = TOKEN_PROGRAM_ID
+) {
+  const ataKey = getAssociatedTokenAddressSync(mint, owner, true, tokenProgram);
+
+  const account = await banksClient.getAccount(ataKey);
+  if (account === null) {
+    const createAtaIx = createAssociatedTokenAccountInstruction(
+      payer.publicKey,
+      ataKey,
+      owner,
+      mint,
+      tokenProgram
+    );
+    let transaction = new Transaction();
+    const [recentBlockhash] = await banksClient.getLatestBlockhash();
+    transaction.recentBlockhash = recentBlockhash;
+    transaction.add(createAtaIx);
+    transaction.sign(payer);
+    await banksClient.processTransaction(transaction);
+  }
+
+  return ataKey;
+}
+
+export async function createToken(
+  banksClient: BanksClient,
+  payer: Keypair,
+  mintAuthority: PublicKey,
+  decimal: number,
+): Promise<PublicKey> {
+  const mintKeypair = Keypair.generate();
+  const rent = await banksClient.getRent();
+  const lamports = rent.minimumBalance(BigInt(MINT_SIZE));
+
+  const createAccountIx = SystemProgram.createAccount({
+    fromPubkey: payer.publicKey,
+    newAccountPubkey: mintKeypair.publicKey,
+    space: MINT_SIZE,
+    lamports: Number(lamports.toString()),
+    programId: TOKEN_PROGRAM_ID,
+  });
+
+  const initializeMintIx = createInitializeMint2Instruction(
+    mintKeypair.publicKey,
+    decimal,
+    mintAuthority,
+    null
+  );
+
+  let transaction = new Transaction();
+  const [recentBlockhash] = await banksClient.getLatestBlockhash();
+  transaction.recentBlockhash = recentBlockhash;
+  transaction.add(createAccountIx, initializeMintIx);
+  transaction.sign(payer, mintKeypair);
+
+  await banksClient.processTransaction(transaction);
+
+  return mintKeypair.publicKey;
+}
+
+export async function wrapSOL(
+  banksClient: BanksClient,
+  payer: Keypair,
+  amount: BN
+) {
+  const solAta = await getOrCreateAssociatedTokenAccount(
+    banksClient,
+    payer,
+    NATIVE_MINT,
+    payer.publicKey
+  );
+
+  const solTransferIx = SystemProgram.transfer({
+    fromPubkey: payer.publicKey,
+    toPubkey: solAta,
+    lamports: BigInt(amount.toString()),
+  });
+
+  const syncNativeIx = createSyncNativeInstruction(solAta);
+
+  let transaction = new Transaction();
+  const [recentBlockhash] = await banksClient.getLatestBlockhash();
+  transaction.recentBlockhash = recentBlockhash;
+  transaction.add(solTransferIx, syncNativeIx);
+  transaction.sign(payer);
+
+  await banksClient.processTransaction(transaction);
+}
+
+export async function mintSplTokenTo(
+  banksClient: BanksClient,
+  payer: Keypair,
+  mint: PublicKey,
+  mintAuthority: Keypair,
+  toWallet: PublicKey,
+  rawAmount: number,
+) {
+  const destination = await getOrCreateAssociatedTokenAccount(
+    banksClient,
+    payer,
+    mint,
+    toWallet
+  );
+
+  const mintIx = createMintToInstruction(
+    mint,
+    destination,
+    mintAuthority.publicKey,
+    rawAmount
+  );
+
+  let transaction = new Transaction();
+  const [recentBlockhash] = await banksClient.getLatestBlockhash();
+  transaction.recentBlockhash = recentBlockhash;
+  transaction.add(mintIx);
+  transaction.sign(payer, mintAuthority);
+
+  await banksClient.processTransaction(transaction);
+}
+
+export async function getMint(banksClient: BanksClient, mint: PublicKey) {
+  const account = await banksClient.getAccount(mint);
+  const mintState = MintLayout.decode(account.data);
+  return mintState;
+}
+
+export async function getTokenAccount(
+  banksClient: BanksClient,
+  key: PublicKey
+) {
+  const account = await banksClient.getAccount(key);
+  const tokenAccountState = AccountLayout.decode(account.data);
+  return tokenAccountState;
+}


### PR DESCRIPTION
workaround for fixed token supply:
- Based on curve, we calculate raw_amount (swap amount + migration amount + locked vesting amount) + raw_amount_with_buffer (swap amount with buffer + migration amount + locked vesting amount)
swap amount with buffer ensures the last swap can go through
Assuming: raw_amount = 15M, raw_amount_with_buffer = 20M (buffer = 5M)
After the last swap, total used token = 18M

- If config key is dynamic supply, then we burn the rest (20 - 18 = 2M): that is how the current flow now
- If config key is fixed supply, then partner need to config 2 variables: pre_migration_supply + post_migration_supply follow the constraints:
15M <= post_migration_supply 
20M <= pre_migration_supply
post_migration_supply <= pre_migration_supply

When token is initialized, we mint pre_migration_supply
When token is migrated, we will check whether we need to burn token to keep it close to post_migration_supply

Some cases:
- post_migration_supply == pre_migration_supply -> no need to burn -> final token supply = pre_migration_supply
- pre_migration_supply = 22M, post_migration_supply = 19M, base vault remains = 22 - 18 = 3M -> burn 3M -> final token supply = 19M
- pre_migration_supply = 20M, post_migration_supply = 17M, base vault remains = 20 - 18 = 2M -> burn 2M  -> final token supply = 18M

